### PR TITLE
Hide the Quicklinks in footer if empty

### DIFF
--- a/layouts/_partials/components/footer/quicklinks.html
+++ b/layouts/_partials/components/footer/quicklinks.html
@@ -1,4 +1,4 @@
-{{- if and .f_quicklink_items (gt (len .f_quicklink_items) 0) -}}
+{{- if .f_quicklink_items -}}
 <div class="col-md-6 col-xl-4 mb-4 mb-md-0">
   <h2 class="h6 wvu-text-letter-spacing-lg wvu-b-label text-uppercase text-wvu-gold mb-3">{{ .heading }}</h2>
   <ul class="list-unstyled lh-sm">

--- a/layouts/_partials/components/footer/quicklinks.html
+++ b/layouts/_partials/components/footer/quicklinks.html
@@ -1,3 +1,4 @@
+{{- if and .f_quicklink_items (gt (len .f_quicklink_items) 0) -}}
 <div class="col-md-6 col-xl-4 mb-4 mb-md-0">
   <h2 class="h6 wvu-text-letter-spacing-lg wvu-b-label text-uppercase text-wvu-gold mb-3">{{ .heading }}</h2>
   <ul class="list-unstyled lh-sm">
@@ -8,3 +9,4 @@
     {{ end }}
   </ul>
 </div>
+{{- end -}}


### PR DESCRIPTION
Fixes wvuweb/wvu-ds-v3-bookshop-components#55