### PR TITLE
Update baseof.html to remove extra topper from faculty profiles.

### DIFF
--- a/layouts/baseof.html
+++ b/layouts/baseof.html
@@ -66,7 +66,7 @@
   {{ end }}
 
   {{ if not .IsHome }}
-    {{ if and (not $topper._bookshop_name) (ne .Kind "term") (ne .Params.type "staff") }}
+    {{ if and (not $topper._bookshop_name) (ne .Kind "term") (ne .Params.type "staff") (ne .Params.type "faculty-profile") }}
       <section aria-labelledby="heading-label">
         <h1 id="heading-label" class="visually-hidden">{{ .Params.title }}</h1>
       </section>


### PR DESCRIPTION
Doing this to fix this issue on the College of Law website that's linked below. We probably need to go through all of the profile types and include them eventually.

https://my2.siteimprove.com/Accessibility/1264717/NextGen/Issue/1?ruleId=64&pageSegments=&issueKind=1&tagFilterType=2&conformance=&siteTargetIssueKinds=1,2&wcagVersion=22&siteTarget.wcagVersion=22&siteTarget.conformanceLevels=0,1,3,4&siteTarget.issueKinds=1,2&siteTarget.scoreType=1